### PR TITLE
Fix simple value merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,32 @@ and with a simple call you can have all of this:
 
 `depth` is how you regulate the depth of the returned dictionary.
 
+<details><summary>Couple gotchas</summary>
+
+### #1
+
+Sometimes you may encounter the following situation:
+
+```
+TERM_PROGRAM=Apple_Terminal
+TERM=xterm-256color
+```
+
+In which case, the return value would still be a dict, but `TERM` value would have an empty key like so:
+
+```python
+>>> import dictenvy
+>>> import pprint
+>>> env = dictenvy.dictate({'TERM': 'xterm-256color', 'TERM_PROGRAM': 'Apple_Terminal'}, depth=1))
+>>> pprint.pprint(env)
+{'term': {'': 'xterm-256color', 'program': 'Apple_Terminal'}}
+```
+
+### #2
+
+Variables that start with an underscore will be left alone.
+</details>
+
 ## Installation
 
 Use pip:
@@ -34,3 +60,7 @@ Use pip:
 ```shell
 $ pip install dict-envy
 ```
+
+## License
+
+MIT

--- a/dictenvy.py
+++ b/dictenvy.py
@@ -6,11 +6,12 @@ def merge(d1, d2):
     """Merges d2 into d1 without overwriting keys."""
     left = d1.copy()
     right = d2.copy()
+
     for key in right.keys():
         if key in left:
             left_is_dict = isinstance(left[key], dict)
             right_is_dict = isinstance(right[key], dict)
-            
+
             if left_is_dict and right_is_dict: 
                 left[key] = merge(left[key], right[key])
             elif right_is_dict:
@@ -21,6 +22,7 @@ def merge(d1, d2):
                 left[key] = right[key]
         else:
             left[key] = right[key]
+
     return left
 
 

--- a/dictenvy.py
+++ b/dictenvy.py
@@ -20,7 +20,7 @@ def merge(d1, d2):
     return ret
 
 
-def __dict_from_key_path(segments, value):
+def _dict_from_key_path(segments, value):
     """Creates a nested dict out of array of keys."""
     ret = {}
     for segment in reversed(segments):
@@ -59,6 +59,6 @@ def dictate(store, depth):
             ret[lkey] = value
             continue
         parts = lkey.split('_', depth)
-        dict_value = __dict_from_key_path(parts, value)
+        dict_value = _dict_from_key_path(parts, value)
         ret = merge(ret, dict_value)
     return ret

--- a/dictenvy.py
+++ b/dictenvy.py
@@ -7,14 +7,20 @@ def merge(d1, d2):
     ret = d1.copy()
     for key in d2.keys():
         if key in ret:
-            if isinstance(ret[key], dict):
-                ret[key].update(merge(ret[key], d2[key]))
+            if isinstance(d2[key], dict) and isinstance(ret[key], dict):
+                ret[key] = merge(ret[key], d2[key])
+            elif isinstance(d2[key], dict):
+                ret[key] = merge({'': ret[key]}, d2[key])
+            elif isinstance(ret[key], dict):
+                ret[key] = merge(ret[key], {'': d2[key]})
+            else:
+                ret[key] = d2[key]
         else:
             ret[key] = d2[key]
     return ret
 
 
-def dict_from_key_path(segments, value):
+def __dict_from_key_path(segments, value):
     """Creates a nested dict out of array of keys."""
     ret = {}
     for segment in reversed(segments):
@@ -29,17 +35,30 @@ def dictate(store, depth):
     """Transforms environment variables into a dictionary.
 
     Key in conjugation with depth is what controls the depth of the nested
-    dicts.
+    dicts. Variables that start with an underscore will be left alone.
+
+    Sometimes you may encounter the following situation:
+
+        TERM_PROGRAM=Apple_Terminal
+        TERM=xterm-256color
+    
+    In which case, the return value would still be a dict, but `TERM` value
+    would have an empty key.
 
     Examples:
         store={'A_B_C': 1}, depth=0 => {'a_b_c': 1}}
         store={'A_B_C': 1}, depth=1 => {'a': {'b_c': 1}}
         store={'A_B_C': 1}, depth=2 => {'a': {'b': {'c': 1}}}
+
+        store={'A': 1, 'A_B': 2}, depth=1 => {'a': {'': '1', 'b': '2'}}
     """
     ret = {}
     for key, value in store.items():
-        # fixme: provide a mapping to dictate() instead of using .replace() on key
-        parts = key.lower().replace('__', '').split('_', depth)
-        dict_value = dict_from_key_path(parts, value)
+        lkey = str(key).lower()
+        if lkey.startswith('_'):
+            ret[lkey] = value
+            continue
+        parts = lkey.split('_', depth)
+        dict_value = __dict_from_key_path(parts, value)
         ret = merge(ret, dict_value)
     return ret

--- a/dictenvy.py
+++ b/dictenvy.py
@@ -7,15 +7,15 @@ def merge(d1, d2):
     ret = d1.copy()
     for key in d2.keys():
         if key in ret:
-            if isinstance(d2[key], dict) and isinstance(ret[key], dict):
+            if isinstance(d2[key], dict) and isinstance(ret[key], dict):  # both sides are dicts
                 ret[key] = merge(ret[key], d2[key])
-            elif isinstance(d2[key], dict):
+            elif isinstance(d2[key], dict):  # left is scalar, right is a dict
                 ret[key] = merge({'': ret[key]}, d2[key])
-            elif isinstance(ret[key], dict):
+            elif isinstance(ret[key], dict):  # left is a dict, right is scalar
                 ret[key] = merge(ret[key], {'': d2[key]})
-            else:
+            else:  # both are scalar
                 ret[key] = d2[key]
-        else:
+        else:  # key was not found in ret
             ret[key] = d2[key]
     return ret
 

--- a/dictenvy.py
+++ b/dictenvy.py
@@ -4,20 +4,24 @@ __version__ = '.'.join(map(str, VERSION))
 
 def merge(d1, d2):
     """Merges d2 into d1 without overwriting keys."""
-    ret = d1.copy()
-    for key in d2.keys():
-        if key in ret:
-            if isinstance(d2[key], dict) and isinstance(ret[key], dict):  # both sides are dicts
-                ret[key] = merge(ret[key], d2[key])
-            elif isinstance(d2[key], dict):  # left is scalar, right is a dict
-                ret[key] = merge({'': ret[key]}, d2[key])
-            elif isinstance(ret[key], dict):  # left is a dict, right is scalar
-                ret[key] = merge(ret[key], {'': d2[key]})
-            else:  # both are scalar
-                ret[key] = d2[key]
-        else:  # key was not found in ret
-            ret[key] = d2[key]
-    return ret
+    left = d1.copy()
+    right = d2.copy()
+    for key in right.keys():
+        if key in left:
+            left_is_dict = isinstance(left[key], dict)
+            right_is_dict = isinstance(right[key], dict)
+            
+            if left_is_dict and right_is_dict: 
+                left[key] = merge(left[key], right[key])
+            elif right_is_dict:
+                left[key] = merge({'': left[key]}, right[key])
+            elif left_is_dict:
+                left[key] = merge(left[key], {'': right[key]})
+            else:
+                left[key] = right[key]
+        else:
+            left[key] = right[key]
+    return left
 
 
 def _dict_from_key_path(segments, value):

--- a/dictenvy.py
+++ b/dictenvy.py
@@ -1,4 +1,4 @@
-VERSION = (0, 1, 1)
+VERSION = (0, 2, 0)
 __version__ = '.'.join(map(str, VERSION))
 
 

--- a/tests.py
+++ b/tests.py
@@ -53,7 +53,7 @@ class TestDictate:
         assert result == {'_a_b': 1}
 
 
-class  TestMerge:
+class TestMerge:
 
     @staticmethod
     def test_merge_single_same_key():

--- a/tests.py
+++ b/tests.py
@@ -1,59 +1,75 @@
+import pytest
 import dictenvy
 
 
-def test_transforms_into_dict():
-    store = {'A': 1}
-    assert dictenvy.dictate(store, depth=1) == {'a': 1}
+class TestDictate:
+
+    @staticmethod
+    def test_transforms_into_dict():
+        store = {'A': 1}
+        result = dictenvy.dictate(store, depth=1)
+        assert result == {'a': 1}
+
+    @staticmethod
+    def test_transforms_into_dict_one_level():
+        store = {'A_B': 1}
+        result = dictenvy.dictate(store, depth=1)
+        assert result == {'a': {'b': 1}}
+
+    @staticmethod
+    def test_transforms_into_dict_one_level_with_one_underscore():
+        store = {'A_B_HELLO': 1}
+        result = dictenvy.dictate(store, depth=1)
+        assert result == {'a': {'b_hello': 1}}
+
+    @staticmethod
+    def test_transforms_into_dict_one_level_with_empty_key():
+        store = {'A': 1, 'A_B': 2}
+        result = dictenvy.dictate(store, depth=1)
+        assert result == {'a': {'': 1, 'b': 2}}
+
+    @staticmethod
+    def test_transforms_into_dict_two_levels():
+        store = {'A_B_C': 1}
+        result = dictenvy.dictate(store, depth=2)
+        assert result == {'a': {'b': {'c': 1}}}
+
+    @staticmethod
+    def test_transforms_into_dict_two_levels_two_items_with_one_underscore():
+        store = {'A_B_C_HELLO': 1, 'A_B_C_WORLD': 2}
+        result = dictenvy.dictate(store, depth=2)
+        assert result == {'a': {'b': {'c_hello': 1, 'c_world': 2}}}
+
+    @staticmethod
+    def test_transforms_into_dict_three_levels_with_two_items():
+        store = {'A_B_C_HELLO': 1, 'A_B_C_WORLD': 2}
+        result = dictenvy.dictate(store, depth=3)
+        assert result == {'a': {'b': {'c': {'hello': 1, 'world': 2}}}}
+
+    @staticmethod
+    def test_variables_starting_with_underscores_are_left_intact():
+        store = {'_A_B': 1}
+        result = dictenvy.dictate(store, depth=1)
+        assert result == {'_a_b': 1}
 
 
-def test_transforms_into_dict_one_level():
-    store = {'A_B': 1}
-    assert dictenvy.dictate(store, depth=1) == {'a': {'b': 1}}
+class  TestMerge:
 
+    @staticmethod
+    def test_merge_single_same_key():
+        d1 = {'a': 2}
+        d2 = {'a': 1}
+        assert dictenvy.merge(d1, d2) == {'a': 1}
 
-def test_transforms_into_dict_one_level_with_one_underscore():
-    store = {'A_B_HELLO': 1}
-    assert dictenvy.dictate(store, depth=1) == {'a': {'b_hello': 1}}
+    @staticmethod
+    def test_merge_same_top_level_key_with_different_children():
+        d1 = {'a': {'b': 1}}
+        d2 = {'a': {'c': 2}}
+        assert dictenvy.merge(d1, d2) == {'a': {'b': 1, 'c': 2}}
 
-
-def test_transforms_into_dict_one_level_with_empty_key():
-    store = {'A': 1, 'A_B': 2}
-    assert dictenvy.dictate(store, depth=1) == {'a': {'': 1, 'b': 2}}
-
-
-def test_transforms_into_dict_two_levels():
-    store = {'A_B_C': 1}
-    assert dictenvy.dictate(store, depth=2) == {'a': {'b': {'c': 1}}}
-
-
-def test_transforms_into_dict_two_levels_two_items_with_one_underscore():
-    store = {'A_B_C_HELLO': 1, 'A_B_C_WORLD': 2}
-    assert dictenvy.dictate(store, depth=2) == {'a': {'b': {'c_hello': 1, 'c_world': 2}}}
-
-
-def test_transforms_into_dict_three_levels_with_two_items():
-    store = {'A_B_C_HELLO': 1, 'A_B_C_WORLD': 2}
-    assert dictenvy.dictate(store, depth=3) == {'a': {'b': {'c': {'hello': 1, 'world': 2}}}}
-
-
-def test_variables_starting_with_underscores_are_left_intact():
-    store = {'_A_B': 1}
-    assert dictenvy.dictate(store, depth=1) == {'_a_b': 1}
-
-
-def test_merge_simple():
-    d1 = {'a': 2}
-    d2 = {'a': 1}
-    assert dictenvy.merge(d1, d2) == {'a': 1}
-
-
-def test_merge_does_not_overwrite_existing_keys():
-    d1 = {'a': {'b': 1}}
-    d2 = {'a': {'c': 2}}
-    assert dictenvy.merge(d1, d2) == {'a': {'b': 1, 'c': 2}}
-
-
-def test_merge_creates_empty_key_for_simple_values():
-    d1 = {'a': 1}
-    d2 = {'a': {'b': 2}}
-    assert dictenvy.merge(d1, d2) == {'a': {'': 1, 'b': 2}}
+    @staticmethod
+    @pytest.mark.parametrize('types', [1, [1], '1'])
+    def test_merge_same_top_level_key_with_different_types(types):
+        d1 = {'a': types}
+        d2 = {'a': {'b': 2}}
+        assert dictenvy.merge(d1, d2) == {'a': {'': types, 'b': 2}}

--- a/tests.py
+++ b/tests.py
@@ -16,6 +16,11 @@ def test_transforms_into_dict_one_level_with_one_underscore():
     assert dictenvy.dictate(store, depth=1) == {'a': {'b_hello': 1}}
 
 
+def test_transforms_into_dict_one_level_with_empty_key():
+    store = {'A': 1, 'A_B': 2}
+    assert dictenvy.dictate(store, depth=1) == {'a': {'': 1, 'b': 2}}
+
+
 def test_transforms_into_dict_two_levels():
     store = {'A_B_C': 1}
     assert dictenvy.dictate(store, depth=2) == {'a': {'b': {'c': 1}}}
@@ -29,3 +34,26 @@ def test_transforms_into_dict_two_levels_two_items_with_one_underscore():
 def test_transforms_into_dict_three_levels_with_two_items():
     store = {'A_B_C_HELLO': 1, 'A_B_C_WORLD': 2}
     assert dictenvy.dictate(store, depth=3) == {'a': {'b': {'c': {'hello': 1, 'world': 2}}}}
+
+
+def test_variables_starting_with_underscores_are_left_intact():
+    store = {'_A_B': 1}
+    assert dictenvy.dictate(store, depth=1) == {'_a_b': 1}
+
+
+def test_merge_simple():
+    d1 = {'a': 2}
+    d2 = {'a': 1}
+    assert dictenvy.merge(d1, d2) == {'a': 1}
+
+
+def test_merge_does_not_overwrite_existing_keys():
+    d1 = {'a': {'b': 1}}
+    d2 = {'a': {'c': 2}}
+    assert dictenvy.merge(d1, d2) == {'a': {'b': 1, 'c': 2}}
+
+
+def test_merge_creates_empty_key_for_simple_values():
+    d1 = {'a': 1}
+    d2 = {'a': {'b': 2}}
+    assert dictenvy.merge(d1, d2) == {'a': {'': 1, 'b': 2}}


### PR DESCRIPTION
This correctly deals with the following situation:

```
TERM_PROGRAM=Apple_Terminal
TERM=xterm-256color
```
Would produce

```python
>>> import dictenvy
>>> import pprint
>>> env = dictenvy.dictate({'TERM': 'xterm-256color', 'TERM_PROGRAM': 'Apple_Terminal'}, depth=1))
>>> pprint.pprint(env)
{'term': {'': 'xterm-256color', 'program': 'Apple_Terminal'}}
```